### PR TITLE
Change how we specify timeout for binder

### DIFF
--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -11,7 +11,6 @@ jobs:
     uses: ProjectPythia/cookbook-actions/.github/workflows/build-book.yaml@main
     with:
       environment_name: cookbook-dev
-      binder_nb_timeout: 3600 # one hour run time
 
   link-check:
     if: ${{ github.repository_owner == 'ProjectPythia' }}

--- a/.github/workflows/publish-book.yaml
+++ b/.github/workflows/publish-book.yaml
@@ -11,7 +11,6 @@ jobs:
     uses: ProjectPythia/cookbook-actions/.github/workflows/build-book.yaml@main
     with:
       environment_name: cookbook-dev
-      binder_nb_timeout: 3600 # one hour run time
 
   deploy:
     needs: build

--- a/.github/workflows/trigger-book-build.yaml
+++ b/.github/workflows/trigger-book-build.yaml
@@ -8,4 +8,3 @@ jobs:
     with:
       environment_name: cookbook-dev
       artifact_name: book-zip-${{ github.event.number }}
-      binder_nb_timeout: 3600 # one hour run time

--- a/_config.yml
+++ b/_config.yml
@@ -9,6 +9,7 @@ copyright: "2022"
 execute:
   # To execute notebooks via a Binder instead, replace 'cache' with 'binder'
   execute_notebooks: binder
+  timeout: 3600  # one hour run time
   allow_errors: False # cells with expected failures must set the `raises-exception` cell tag
 
 # Add a few extensions to help with parsing content


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
#17 was experimental. This PR sets things straight.

We now specify a timeout value for the binder with the `timeout` field in the _config file, same as vanilla JupyterBook. 

This PR should get the builds working again for this cookbook.