### PR TITLE
Use more recent python

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: cla-cookbook-dev
 channels:
   - conda-forge
 dependencies:
-  - python=3.9
+  - python>=3.10
   - jupyter-book
   - jupyterlab
   - matplotlib


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
I don't think there's any good reason to pin to python=3.9, so I'm getting rid of that here.