### PR TITLE
Python <3.12 and eliminate commented-out code in notebook

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: cla-cookbook-dev
 channels:
   - conda-forge
 dependencies:
-  - python>=3.10
+  - python<3.12
   - jupyter-book
   - jupyterlab
   - matplotlib

--- a/notebooks/example-workflows/key-figures.ipynb
+++ b/notebooks/example-workflows/key-figures.ipynb
@@ -816,20 +816,20 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Create an Xarray `Dataset` from the Zarr object"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "ds = xr.open_zarr(store, consolidated=True, chunks=\"auto\") # , use_cftime=True,decode_cf=False)\n",
+    "ds = xr.open_zarr(store, consolidated=True, chunks=\"auto\")\n",
     "ds"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create an Xarray `Dataset` from the Zarr object"
    ]
   },
   {
@@ -1039,7 +1039,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.11.9"
   },
   "nbdime-conflicts": {
    "local_diff": [


### PR DESCRIPTION
Rule out Python 3.12 as a source of the kernel crashing on Binder
